### PR TITLE
Add nested associations

### DIFF
--- a/archie.go
+++ b/archie.go
@@ -53,7 +53,7 @@ func (a *archie) LandscapeView() (diagram string, err error) {
 // the parent is an ancestor of scope, or it is a root element.
 func (a *archie) ContextView(scope string) (diagram string, err error) {
 	// Lookup the element
-	element, err := a.model.LookupName(scope)
+	element, err := a.model.LookupName(scope, nil)
 	if err != nil {
 		return
 	}
@@ -72,7 +72,7 @@ func (a *archie) ContextView(scope string) (diagram string, err error) {
 // the parent is an ancestor of scope, or it is a root element.
 func (a *archie) TagView(scope, tag string) (diagram string, err error) {
 	// Lookup the element
-	element, err := a.model.LookupName(scope)
+	element, err := a.model.LookupName(scope, nil)
 	if err != nil {
 		return
 	}

--- a/internal/io/read_test.go
+++ b/internal/io/read_test.go
@@ -1,10 +1,12 @@
 package io
 
 import (
-	mdl "github.com/briggysmalls/archie/internal/model"
 	"testing"
 
+	mdl "github.com/briggysmalls/archie/internal/model"
+
 	"fmt"
+
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 )
@@ -34,6 +36,10 @@ elements:
             tags: [electronics, mechanical]
           - name: input select
             tags: [electronics, mechanical]
+        associations:
+          - source: ac-dc converter
+            destination: amplifier circuit
+
 associations:
   - source: user
     destination: sound system/amplifier/input select
@@ -46,8 +52,6 @@ associations:
   - source: sound system/amplifier/ac-dc converter
     destination: sound system/amplifier/mixer
     tag: power
-  - source: sound system/amplifier/ac-dc converter
-    destination: sound system/amplifier/amplifier circuit
   - source: sound system/amplifier/amplifier circuit
     destination: sound system/amplifier/audio out connector
   - source: sound system/amplifier/audio out connector
@@ -78,15 +82,20 @@ func TestRead(t *testing.T) {
 	assertChildrenCount(t, m, "sound system/amplifier", 7)
 	// Check some element tags
 	assertElementTags(t, m, "sound system/speaker/driver", []string{"electronics", "mechanical"})
+
 	// Check some association tags
 	ass, err := findFirstAssociation(m, "user", "input select")
 	assert.NilError(t, err)
 	assert.Equal(t, ass.Tag(), "press")
+
+	// Check nested association
+	ass, err = findFirstAssociation(m, "ac-dc converter", "amplifier circuit")
+	assert.NilError(t, err)
 }
 
 func assertChildrenCount(t *testing.T, m *mdl.Model, name string, length int) {
 	// Lookup the name
-	el, err := m.LookupName(name)
+	el, err := m.LookupName(name, nil)
 	assert.NilError(t, err)
 	// Now assert the number of children is as expected
 	assert.Assert(t, is.Len(m.Children(el), length))
@@ -94,7 +103,7 @@ func assertChildrenCount(t *testing.T, m *mdl.Model, name string, length int) {
 
 func assertElementTags(t *testing.T, m *mdl.Model, name string, expected []string) {
 	// Lookup the name
-	el, err := m.LookupName(name)
+	el, err := m.LookupName(name, nil)
 	assert.NilError(t, err)
 	// Assert the tag slices match
 	tags := el.Tags()

--- a/internal/io/types.go
+++ b/internal/io/types.go
@@ -6,17 +6,18 @@ type Model struct {
 	Associations []Association `json:"associations"`
 }
 
-// Element holds a parsed Archie element (actor or item)
-type Element struct {
-	Name     string        `json:"name"`
-	Kind     string        `json:"kind,omitempty"`
-	Tags     []string      `json:"technology,omitempty"`
-	Children []interface{} `json:"children,omitempty"`
-}
-
 // Association holds a parsed Archie association
 type Association struct {
 	Source      string `json:"source"`
 	Destination string `json:"destination"`
 	Tag         string `json:"tag"`
+}
+
+// Element holds a parsed Archie element (actor or item)
+type Element struct {
+	Name         string        `json:"name"`
+	Kind         string        `json:"kind,omitempty"`
+	Tags         []string      `json:"technology,omitempty"`
+	Children     []interface{} `json:"children,omitempty"`
+	Associations []Association `json:"associations,omitempty"`
 }

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -196,12 +196,10 @@ func (m *Model) getRoot(element Element) Element {
 }
 
 // LookupName returns a model element corresponding to the fully-namespaced name.
-func (m *Model) LookupName(name string) (Element, error) {
+func (m *Model) LookupName(name string, parent Element) (Element, error) {
 	// Split the string by slashes
 	parts := strings.Split(name, "/")
 	// Search down the tree
-	var parent Element
-	parent = nil
 NameLoop:
 	for i, name := range parts {
 		// Look for a child with the given name

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -154,7 +154,7 @@ func assertParent(t *testing.T, m *Model, child Element, parent Element) {
 
 func assertName(t *testing.T, m *Model, el Element, name string) {
 	// Try to look up the name
-	result, err := m.LookupName(name)
+	result, err := m.LookupName(name, nil)
 	assert.NilError(t, err)
 	// Now check they match
 	assert.Equal(t, el, result)


### PR DESCRIPTION
This PR makes it possible to add associations to any child. The source
and destination can then be specified relatively. This increases the
locality of information and eases refactoring of bigger systems.