### PR TITLE
Change yaml to be strict and remove unused config flag

### DIFF
--- a/cli/cmd/generate.go
+++ b/cli/cmd/generate.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
+
 	"github.com/briggysmalls/archie"
 	"github.com/briggysmalls/archie/cli/utils"
 	"github.com/spf13/cobra"
-	"io/ioutil"
 )
 
 var view string

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -3,14 +3,10 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"os"
 
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/spf13/viper"
+	"github.com/spf13/cobra"
 )
-
-var cfgFile string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -26,36 +22,6 @@ for developing lightweight system architecture modules`,
 func Execute() {
 	err := rootCmd.Execute()
 	handleError(err)
-}
-
-func init() {
-	cobra.OnInitialize(initConfig)
-
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.archie-cli.yaml)")
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		handleError(err)
-
-		// Search config in home directory with name ".archie-cli" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".archie-cli")
-	}
-
-	viper.SetEnvPrefix("ARCHIE")
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Println("Using config file:", viper.ConfigFileUsed())
-	}
 }
 
 func handleError(err error) {

--- a/cli/utils/utils.go
+++ b/cli/utils/utils.go
@@ -15,10 +15,11 @@ type parsedModelAndConfig struct {
 	Config config      `yaml:""`
 }
 
+// ReadModel reads a yaml into a archie structure
 func ReadModel(modelAndConfig []byte) (archie.Archie, error) {
 	// Separate config and model
 	p := parsedModelAndConfig{}
-	err := yaml.Unmarshal(modelAndConfig, &p)
+	err := yaml.UnmarshalStrict(modelAndConfig, &p)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,9 @@ module github.com/briggysmalls/archie
 go 1.12
 
 require (
-	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.3.0 // indirect
 	github.com/gorilla/mux v1.7.3
 	github.com/magiconair/properties v1.8.1 // indirect
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1 // indirect

--- a/internal/io/read.go
+++ b/internal/io/read.go
@@ -4,15 +4,15 @@ import (
 	"fmt"
 
 	mdl "github.com/briggysmalls/archie/internal/model"
-	"github.com/ghodss/yaml"
 	"github.com/mitchellh/mapstructure"
+	"gopkg.in/yaml.v2"
 )
 
 // ParseYaml parses an API model from a yaml string
 func ParseYaml(data string) (*mdl.Model, error) {
 	// Parse the yaml using the package
 	var sModel Model
-	err := yaml.Unmarshal([]byte(data), &sModel)
+	err := yaml.UnmarshalStrict([]byte(data), &sModel)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Now that the config is part of the architecture yaml file the config flag is no longer used anywhere.
Additionally, if a invalid yaml was submitted the error was opaque. I somewhat improved that by making yaml unmarshaling strict and therefore returning an error if yaml structure does not match.