### PR TITLE
Fix root associations

### DIFF
--- a/internal/io/read.go
+++ b/internal/io/read.go
@@ -73,21 +73,29 @@ func addChildren(model *mdl.Model, parent mdl.Element, children []interface{}) e
 		case map[string]interface{}:
 			// Map into an element structure
 			var el Element
-			err := mapstructure.Decode(i, &el)
+			var err error
+			err = mapstructure.Decode(i, &el)
 			if err != nil {
 				return err
 			}
 			// Map into an element structure
-			updateModelAndRecurse(model, parent, el)
+			err = updateModelAndRecurse(model, parent, el)
+			if err != nil {
+				return err
+			}
 		case map[interface{}]interface{}:
 			// See: https://github.com/go-yaml/yaml/issues/139
 			// Map into an element structure
 			var el Element
-			err := mapstructure.Decode(i, &el)
+			var err error
+			err = mapstructure.Decode(i, &el)
 			if err != nil {
 				return err
 			}
-			updateModelAndRecurse(model, parent, el)
+			err = updateModelAndRecurse(model, parent, el)
+			if err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("Unexpected type %T", i)
 		}
@@ -99,7 +107,9 @@ func updateModelAndRecurse(model *mdl.Model, parent mdl.Element, el Element) err
 
 	// Handle creating actors
 	if el.Kind == "actor" {
-		// TODO assert that actor can only be in a root
+		if parent != nil {
+			return fmt.Errorf("Only root elements can be actors, element %s is not.", el.Name)
+		}
 		new := mdl.NewActor(el.Name)
 		model.AddElement(new, parent)
 		return nil

--- a/internal/io/read_test.go
+++ b/internal/io/read_test.go
@@ -39,6 +39,9 @@ elements:
         associations:
           - source: ac-dc converter
             destination: amplifier circuit
+    associations:
+      - source: user
+        destination: amplifier/mixer
 
 associations:
   - source: user
@@ -90,6 +93,10 @@ func TestRead(t *testing.T) {
 
 	// Check nested association
 	ass, err = findFirstAssociation(m, "ac-dc converter", "amplifier circuit")
+	assert.NilError(t, err)
+
+	// Check nested association on root element
+	ass, err = findFirstAssociation(m, "user", "mixer")
 	assert.NilError(t, err)
 }
 

--- a/internal/io/read_test.go
+++ b/internal/io/read_test.go
@@ -40,8 +40,8 @@ elements:
           - source: ac-dc converter
             destination: amplifier circuit
     associations:
-	  - source: amplifier/audio out connector
-		destination: speaker/cable
+      - source: amplifier/audio out connector
+        destination: speaker/cable
 
 associations:
   - source: user

--- a/internal/io/read_test.go
+++ b/internal/io/read_test.go
@@ -40,8 +40,8 @@ elements:
           - source: ac-dc converter
             destination: amplifier circuit
     associations:
-      - source: user
-        destination: amplifier/mixer
+	  - source: amplifier/audio out connector
+		destination: speaker/cable
 
 associations:
   - source: user
@@ -57,8 +57,6 @@ associations:
     tag: power
   - source: sound system/amplifier/amplifier circuit
     destination: sound system/amplifier/audio out connector
-  - source: sound system/amplifier/audio out connector
-    destination: sound system/speaker/cable
   - source: sound system/speaker/cable
     destination: sound system/speaker/connector
   - source: sound system/speaker/connector
@@ -96,7 +94,7 @@ func TestRead(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Check nested association on root element
-	ass, err = findFirstAssociation(m, "user", "mixer")
+	ass, err = findFirstAssociation(m, "audio out connector", "cable")
 	assert.NilError(t, err)
 }
 


### PR DESCRIPTION
I did not notice the special case for root assertions and failed to add associations for them in previous PR. To fix it instead I refactored the update
model func so it would with root level elements.