### PR TITLE
Create opportunity for different writers

### DIFF
--- a/cli/archie/utils/utils.go
+++ b/cli/archie/utils/utils.go
@@ -4,9 +4,11 @@ import (
 	"github.com/briggysmalls/archie"
 	"github.com/briggysmalls/archie/writers"
 	"gopkg.in/yaml.v2"
+	"fmt"
 )
 
 type config struct {
+	Writer string `yaml:""`
 	Footer string `yaml:""`
 }
 
@@ -23,13 +25,22 @@ func ReadModel(modelAndConfig []byte) (archie.Archie, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Create an Archie from the model & config
+	// Get the model as yaml
 	model, err := yaml.Marshal(p.Model)
 	if err != nil {
 		return nil, err
 	}
 	// Create a writer, using the provided config
-	writer := writers.PlantUmlStrategy{CustomFooter: p.Config.Footer}
+	var writer writers.Strategy
+	switch p.Config.Writer {
+	case "":
+		// Assume plantuml if not specified explicitly
+		fallthrough
+	case "plantuml":
+		writer = writers.PlantUmlStrategy{CustomFooter: p.Config.Footer}
+	default:
+		return nil, fmt.Errorf("Unexpected writer strategy: %s", p.Config.Writer)
+	}
 	// Create an archie instance with the writer and model
 	archie, err := archie.New(writer, string(model))
 	return archie, err


### PR DESCRIPTION
Fixes #24.

This adds logic to check the `config` section of the modelAndConfig yaml file to determine which writer strategy to employ.