### PR TITLE
Improve writer tests

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -129,11 +130,16 @@ func (m *Model) Parent(element Element) (Element, error) {
 // Children gets the children of a specified element.
 func (m *Model) Children(element Element) []Element {
 	var children []Element
+	// Get the elements
 	for child, parent := range m.Composition {
 		if parent == element {
 			children = append(children, child)
 		}
 	}
+	// Sort elements by name
+	sort.Slice(children, func(i, j int) bool {
+		return children[i].Name() < children[j].Name()
+	})
 	return children
 }
 

--- a/writers/plantuml_test.go
+++ b/writers/plantuml_test.go
@@ -22,15 +22,17 @@ skinparam ranksep 20
 
 	const resultFormat = `@startuml
 package "One" <<software>> {
-	rectangle "OneChild" as %[1]s
+    rectangle "OneChild" as %[1]s
 }
 rectangle "Two" as %[2]s <<software>><<mechanical>>
+actor "User" as %[3]s
 %[1]s --> %[2]s
+
 skinparam shadowing false
 skinparam nodesep 10
 skinparam ranksep 20
 @enduml
 `
 	// Assert result
-	assert.Equal(t, output, fmt.Sprintf(resultFormat, elMap["OneChild"].ID(), elMap["Two"].ID()))
+	assert.Equal(t, output, fmt.Sprintf(resultFormat, elMap["OneChild"].ID(), elMap["Two"].ID(), elMap["User"].ID()))
 }

--- a/writers/plantuml_test.go
+++ b/writers/plantuml_test.go
@@ -3,8 +3,6 @@ package writers
 import (
 	"fmt"
 	"gotest.tools/assert"
-	is "gotest.tools/assert/cmp"
-	"strings"
 	"testing"
 )
 
@@ -22,26 +20,17 @@ skinparam ranksep 20
 	output, err := d.Write(*m)
 	assert.NilError(t, err)
 
+	const resultFormat = `@startuml
+package "One" <<software>> {
+	rectangle "OneChild" as %[1]s
+}
+rectangle "Two" as %[2]s <<software>><<mechanical>>
+%[1]s --> %[2]s
+skinparam shadowing false
+skinparam nodesep 10
+skinparam ranksep 20
+@enduml
+`
 	// Assert result
-	lines := strings.Split(output, "\n")
-	assert.Equal(t, lines[0], "@startuml")
-	// Find the line with the parent object definition
-	parentString := "package \"One\" <<software>> {"
-	assert.Assert(t, is.Contains(lines, parentString))
-	var parentLine uint
-	for i, line := range lines[1:] {
-		if line == parentString {
-			parentLine = uint(i + 1)
-		}
-	}
-	assert.Equal(t, lines[parentLine+1], fmt.Sprintf("    rectangle \"OneChild\" as %s", elMap["OneChild"].ID()))
-	assert.Equal(t, lines[parentLine+2], "}")
-	assert.Assert(t, is.Contains(lines, fmt.Sprintf("actor \"User\" as %s", elMap["User"].ID())))
-	assert.Assert(t, is.Contains(lines, fmt.Sprintf("rectangle \"Two\" as %s <<software>><<mechanical>>", elMap["Two"].ID())))
-	assert.Assert(t, is.Contains(lines, fmt.Sprintf("%s --> %s", elMap["OneChild"].ID(), elMap["Two"].ID())))
-
-	assert.Assert(t, is.Contains(lines, "skinparam shadowing false"))
-	assert.Assert(t, is.Contains(lines, "skinparam nodesep 10"))
-	assert.Assert(t, is.Contains(lines, "skinparam ranksep 20"))
-	assert.Equal(t, lines[len(lines)-2], "@enduml")
+	assert.Equal(t, output, fmt.Sprintf(resultFormat, elMap["OneChild"].ID(), elMap["Two"].ID()))
 }

--- a/writers/plantuml_test.go
+++ b/writers/plantuml_test.go
@@ -2,31 +2,15 @@ package writers
 
 import (
 	"fmt"
-	mdl "github.com/briggysmalls/archie/internal/model"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	"strings"
 	"testing"
 )
 
-func TestDraw(t *testing.T) {
-	// Create a simple model
-	m := mdl.NewModel()
-
-	// Create the items we'll be testing
-	actor := mdl.NewActor("User")
-	one := mdl.NewItem("One", []string{"software"})
-	oneChild := mdl.NewItem("OneChild", nil)
-	two := mdl.NewItem("Two", []string{"software", "mechanical"})
-
-	// Add the items, and their relationships to the model
-	m.AddRootElement(actor)
-	m.AddRootElement(one)
-	m.AddElement(oneChild, one)
-	m.AddRootElement(two)
-
-	// Link the children together
-	m.AddAssociation(oneChild, two, "")
+func TestDrawPlantuml(t *testing.T) {
+	// Create the test model
+	m, elMap := createTestModel()
 
 	// Drawer
 	customFooter := `
@@ -35,7 +19,7 @@ skinparam nodesep 10
 skinparam ranksep 20
 `
 	d := New(PlantUmlStrategy{CustomFooter: customFooter})
-	output, err := d.Write(m)
+	output, err := d.Write(*m)
 	assert.NilError(t, err)
 
 	// Assert result
@@ -50,11 +34,11 @@ skinparam ranksep 20
 			parentLine = uint(i + 1)
 		}
 	}
-	assert.Equal(t, lines[parentLine+1], fmt.Sprintf("    rectangle \"OneChild\" as %s", oneChild.ID()))
+	assert.Equal(t, lines[parentLine+1], fmt.Sprintf("    rectangle \"OneChild\" as %s", elMap["OneChild"].ID()))
 	assert.Equal(t, lines[parentLine+2], "}")
-	assert.Assert(t, is.Contains(lines, fmt.Sprintf("actor \"User\" as %s", actor.ID())))
-	assert.Assert(t, is.Contains(lines, fmt.Sprintf("rectangle \"Two\" as %s <<software>><<mechanical>>", two.ID())))
-	assert.Assert(t, is.Contains(lines, fmt.Sprintf("%s --> %s", oneChild.ID(), two.ID())))
+	assert.Assert(t, is.Contains(lines, fmt.Sprintf("actor \"User\" as %s", elMap["User"].ID())))
+	assert.Assert(t, is.Contains(lines, fmt.Sprintf("rectangle \"Two\" as %s <<software>><<mechanical>>", elMap["Two"].ID())))
+	assert.Assert(t, is.Contains(lines, fmt.Sprintf("%s --> %s", elMap["OneChild"].ID(), elMap["Two"].ID())))
 
 	assert.Assert(t, is.Contains(lines, "skinparam shadowing false"))
 	assert.Assert(t, is.Contains(lines, "skinparam nodesep 10"))

--- a/writers/plantuml_test.go
+++ b/writers/plantuml_test.go
@@ -1,7 +1,6 @@
 package writers
 
 import (
-	"fmt"
 	"gotest.tools/assert"
 	"testing"
 )
@@ -34,5 +33,5 @@ skinparam ranksep 20
 @enduml
 `
 	// Assert result
-	assert.Equal(t, output, fmt.Sprintf(resultFormat, elMap["OneChild"].ID(), elMap["Two"].ID(), elMap["User"].ID()))
+	assertOutput(t, output, resultFormat, []string{elMap["OneChild"].ID(), elMap["Two"].ID(), elMap["User"].ID()})
 }

--- a/writers/test_utils.go
+++ b/writers/test_utils.go
@@ -1,0 +1,35 @@
+package writers
+
+import (
+	mdl "github.com/briggysmalls/archie/internal/model"
+)
+
+func createTestModel() (*mdl.Model, map[string]mdl.Element) {
+	// Create a simple model
+	m := mdl.NewModel()
+
+	// Create the items we'll be testing
+	actor := mdl.NewActor("User")
+	one := mdl.NewItem("One", []string{"software"})
+	oneChild := mdl.NewItem("OneChild", nil)
+	two := mdl.NewItem("Two", []string{"software", "mechanical"})
+
+	// Add the items, and their relationships to the model
+	m.AddRootElement(actor)
+	m.AddRootElement(one)
+	m.AddElement(oneChild, one)
+	m.AddRootElement(two)
+
+	// Link the children together
+	m.AddAssociation(oneChild, two, "")
+
+	// Create the map
+	elMap := map[string]mdl.Element{
+		"User": actor,
+		"One": one,
+		"OneChild": oneChild,
+		"Two": two,
+	}
+
+	return &m, elMap
+}

--- a/writers/test_utils.go
+++ b/writers/test_utils.go
@@ -1,7 +1,10 @@
 package writers
 
 import (
+	"fmt"
 	mdl "github.com/briggysmalls/archie/internal/model"
+	"gotest.tools/assert"
+	"testing"
 )
 
 func createTestModel() (*mdl.Model, map[string]mdl.Element) {
@@ -25,11 +28,19 @@ func createTestModel() (*mdl.Model, map[string]mdl.Element) {
 
 	// Create the map
 	elMap := map[string]mdl.Element{
-		"User": actor,
-		"One": one,
+		"User":     actor,
+		"One":      one,
 		"OneChild": oneChild,
-		"Two": two,
+		"Two":      two,
 	}
 
 	return &m, elMap
+}
+
+func assertOutput(t *testing.T, output string, formatString string, IDs []string) {
+	var IDsInterface []interface{} = make([]interface{}, len(IDs))
+	for i, d := range IDs {
+		IDsInterface[i] = d
+	}
+	assert.Equal(t, output, fmt.Sprintf(formatString, IDsInterface...))
 }


### PR DESCRIPTION
This MR makes a small change to how a model returns its children, sorting elements by their name.

This means that tests can be simplified, asserting the entire output of the test